### PR TITLE
Fix encoding issue happening when providing URLs containing UTF-8 characters

### DIFF
--- a/app/assets/javascripts/i18n_viz/settings.js.coffee.erb
+++ b/app/assets/javascripts/i18n_viz/settings.js.coffee.erb
@@ -1,3 +1,4 @@
+<%# encoding: utf-8 %>
 window.I18nViz = {
   regex:             new RegExp(/--([a-z0-9_\.]+)--/i),
   global_regex:      new RegExp(/--([a-z0-9_\.]+)--/gi),


### PR DESCRIPTION
This commit fixes an exception raised by ERB in `i18n_viz/settings.js.coffee.erb` when an `external_tool_url` is passed with UTF-8 characters.

For instance:

I18nViz.external_tool_url = "https://webtranslateit.com/en/projects/406/locales/en..fr/strings?utf8=✓&s="

See related issue: #2
