### PR TITLE
Set text color to a black, sans serif font

### DIFF
--- a/app/assets/stylesheets/i18n_viz.css
+++ b/app/assets/stylesheets/i18n_viz.css
@@ -4,18 +4,17 @@
   position: absolute;
   top: 100px;
   left: 200px;
-  border: 2px solid #a9a9a9;
+  border: 2px solid darkgrey;
   -webkit-border-radius: 5px;
   -moz-border-radius: 5px;
   -ms-border-radius: 5px;
   -o-border-radius: 5px;
   border-radius: 5px;
-  background-color: #f5f5f5;
+  background-color: whitesmoke;
   background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #ffffff), color-stop(100%, #f5f5f5));
   background-image: -webkit-linear-gradient(#ffffff, #f5f5f5);
   background-image: -moz-linear-gradient(#ffffff, #f5f5f5);
   background-image: -o-linear-gradient(#ffffff, #f5f5f5);
-  background-image: -ms-linear-gradient(#ffffff, #f5f5f5);
   background-image: linear-gradient(#ffffff, #f5f5f5);
   padding: 10px;
   z-index: 999;
@@ -23,18 +22,21 @@
 /* line 15, ../../../sass/i18n_viz.css.sass */
 #i18n_viz_tooltip a, #i18n_viz_tooltip span {
   margin-right: 10px;
+  color: #111111;
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-size: 12px;
 }
-/* line 17, ../../../sass/i18n_viz.css.sass */
+/* line 20, ../../../sass/i18n_viz.css.sass */
 #i18n_viz_tooltip a:last-child, #i18n_viz_tooltip span:last-child {
   margin-right: 0;
 }
 
-/* line 20, ../../../sass/i18n_viz.css.sass */
+/* line 23, ../../../sass/i18n_viz.css.sass */
 .i18n-viz {
   cursor: help;
   background: lightyellow !important;
 }
-/* line 23, ../../../sass/i18n_viz.css.sass */
+/* line 26, ../../../sass/i18n_viz.css.sass */
 .i18n-viz:hover {
   color: black;
   background: yellow !important;

--- a/sass/i18n_viz.css.sass
+++ b/sass/i18n_viz.css.sass
@@ -14,9 +14,12 @@
   z-index: 999
   a, span
     margin-right: 10px
+    color: #111
+    font-family: "Helvetica Neue", Arial, sans-serif
+    font-size: 12px
     &:last-child
       margin-right: 0
-  
+
 .i18n-viz
   cursor: help
   background: lightyellow !important


### PR DESCRIPTION
Hey, here’s another pull request/suggestion to set the text in the tooltip to a black, sans-serif font.

Currently the tooltip text use the color of `span` or `a` defined by the application i18n_viz is running on. In this particular case the text was white on a white background.

Before:

![before](https://f.cloud.github.com/assets/30716/107024/c085f06a-6a1a-11e2-9f06-9c043fdbc8a2.png)

After:

![after](https://f.cloud.github.com/assets/30716/107013/60edb142-6a1a-11e2-8be1-8083ab425c8b.png)

Thanks!
