### PR TITLE
Catch error when contents method raises exception

### DIFF
--- a/app/assets/javascripts/i18n_viz/utils.js.coffee
+++ b/app/assets/javascripts/i18n_viz/utils.js.coffee
@@ -1,8 +1,11 @@
 # get all the textnode children for an element
 # edited
 $.fn.textNodes = () ->
-  $(this).contents().filter () ->
-    try
-      (this.nodeType == 3)
-    catch err
-      false
+  try
+    $(this).contents().filter () ->
+      try
+        (this.nodeType == 3)
+      catch err
+        false
+  catch e
+    []


### PR DESCRIPTION
This commit fixes exception when calling contents method is not allowed for security reasons.

![contents error](https://f.cloud.github.com/assets/5878206/1832774/1e183d80-73bd-11e3-9220-da497c8e6b64.png)

![chrome error](https://f.cloud.github.com/assets/5878206/1832794/89a26c2e-73bd-11e3-9722-c9376b66b00f.png)
