### PR TITLE
return empty jquery object

### DIFF
--- a/app/assets/javascripts/i18n_viz/utils.js.coffee
+++ b/app/assets/javascripts/i18n_viz/utils.js.coffee
@@ -8,4 +8,4 @@ $.fn.textNodes = () ->
       catch err
         false
   catch e
-    []
+    $([])


### PR DESCRIPTION
In case that calling contents in not allowed on element return empty jquery object instead of empty array.
