### PR TITLE
Compatibility with ActionView's lazy lookup

### DIFF
--- a/lib/i18n_viz/view_helpers.rb
+++ b/lib/i18n_viz/view_helpers.rb
@@ -7,7 +7,7 @@ module I18nViz
         if !options[:scope].blank? 
           "#{super(key, options)}--#{options[:scope].to_s}.#{key}--"
         else
-          "#{super(key, options)}--#{key}--"
+          "#{super(key, options)}--#{scope_key_by_partial(key)}--"
         end
       else
         super(key, options)


### PR DESCRIPTION
Translation keys beginning with '.' were taken as is by i18n_viz, not
generating the full key, making it quite useless.

This pull request introduces the use of ActionView's method "scope_key_by_partial", used in the translate method to get the full scope automatically based on the current view.

Please note that this introduces a hard dependency on ActionView. If you wish to become Rails agnostic, a different implementation testing the existence of this method is necessary.

This was tested and implemented on Rails 4. I unfortunately lack time to test it on older versions of Rails.
