### PR TITLE
Keep nested HTML tags when removing i18n keys. Fixes #9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 now a middleware which takes care of all the css and js injection and only does
 this when `i18n_viz` is in the query string.
 
+* [bugfix] keep nested HTML tags when removing i18n keys. Fixes #9
+
 ## 0.4.0
 
 * [bugfix] tooltip displays correct key for translations that are using :scope option

--- a/assets/javascripts/i18n_viz.js
+++ b/assets/javascripts/i18n_viz.js
@@ -43,8 +43,8 @@ $.fn.enrichWithI18nData = function() {
 $.fn.clearI18nText = function() {
   var $el;
   $el = $(this);
-  $el.textNodes().each(function() {
-    return $el.text($el.text().replace(I18nViz.global_regex, ""));
+  $el.textNodes().each(function(index, node) {
+    node.textContent = node.textContent.replace(I18nViz.global_regex, "");
   });
   return $el;
 };

--- a/spec/javascripts/i18n_viz_spec.coffee
+++ b/spec/javascripts/i18n_viz_spec.coffee
@@ -23,6 +23,13 @@ describe "jQuery extensions", () ->
         $jquery_element.clearI18nText()
         expect($jquery_element.text()).toEqual("some text ")
 
+      it "should keep child HTML tags", () ->
+        $jquery_element.append($("<span>some more text --i18n.key2--</span>"))
+        $jquery_element.clearI18nText()
+        expect($jquery_element.text()).toEqual("some text some more text ")
+        expect($jquery_element.has('span')).toBeTruthy()
+        expect($jquery_element.find('span').text()).toEqual("some more text ")
+
     describe "$.fn.enrichWithI18nData()", () ->
       it "should enrich element with i18n data", () ->
         $jquery_element.enrichWithI18nData()

--- a/test/dummy/app/views/test/test.html.erb
+++ b/test/dummy/app/views/test/test.html.erb
@@ -1,3 +1,7 @@
 <span><%= t("hello") %></span>
 <span><%= translate("foo", :i18n_viz => false) %></span>
 <span><%= translate("bar", :scope => :scope) %></span>
+<h1>
+    <%= t("hello") %>
+    <span><%= translate("bar", :scope => :scope) %></span>
+</h1>


### PR DESCRIPTION
As of now there is a slight side effect from i18n_viz, because it removes nested HTML tags when they are present inside the translated content. This causes websites to be displayed differently.

The proposed patch fixes this for me and it can be manually validated using the test.html.erb file. However I'm not able to get the automated test running. For some reason only the first i18n key is replaced and the seconds is left as-is causing the test to fail for me.