### PR TITLE
Check cookie value as well as query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 now a middleware which takes care of all the css and js injection and only does
 this when `i18n_viz` is in the query string.
 * [improvement] added `I18nViz.css_override` setting
+* [improvement] added the ability to use a `i18n_viz` cookie
 
 ## 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ if you want to configure CSS overrides
 
 Add the `i18n_viz=true` parameter to visualize the translatable segments.
 
+Alternatively, a cookie with the name `i18n_viz` can be set to any value to achieve the same effect.
+
 
 ## How it works
 

--- a/lib/i18n_viz/view_helpers.rb
+++ b/lib/i18n_viz/view_helpers.rb
@@ -23,7 +23,14 @@ module I18nViz
     end
 
     def display_i18n_viz?
-      params && params[:i18n_viz] rescue false # rescue workaround, because params is weirdly defined in e.g. ActionMailer
+      check_params rescue false # rescue workaround, because params is weirdly defined in e.g. ActionMailer
+    end
+
+    private
+
+    def check_params
+      return true if params && params[:i18n_viz]
+      return true if cookies && cookies[:i18n_viz]
     end
 
   end

--- a/lib/i18n_viz/view_helpers.rb
+++ b/lib/i18n_viz/view_helpers.rb
@@ -1,11 +1,10 @@
 module I18nViz
   module ViewHelpers
-
     def translate(key, options = {}) # TODO: alias
       if display_i18n_viz? && options[:i18n_viz] != false
         # TODO: ActionController::Base.perform_caching = false  if ActionController::Base.perform_caching == true
         if !options[:scope].blank?
-          "#{super(key, options)}--#{options[:scope].to_s}.#{scope_key_by_partial(key)}--"
+          "#{super(key, options)}--#{options[:scope]}.#{scope_key_by_partial(key)}--"
         else
           "#{super(key, options)}--#{scope_key_by_partial(key)}--"
         end
@@ -13,17 +12,19 @@ module I18nViz
         super(key, options)
       end
     end
-    alias :t :translate
+    alias t translate
 
     def i18n_viz_include_tag # TODO: doesn't work yet
       return unless display_i18n_viz?
 
-      stylesheet_link_tag("i18n_viz")
-      javascript_include_tag "i18n_viz"
+      stylesheet_link_tag 'i18n_viz'
+      javascript_include_tag 'i18n_viz'
     end
 
     def display_i18n_viz?
-      check_params rescue false # rescue workaround, because params is weirdly defined in e.g. ActionMailer
+      check_params
+    rescue
+      false # rescue workaround, because params is weirdly defined in e.g. ActionMailer
     end
 
     private
@@ -32,6 +33,5 @@ module I18nViz
       return true if params && params[:i18n_viz]
       return true if cookies && cookies[:i18n_viz]
     end
-
   end
 end


### PR DESCRIPTION
Setting a cookie with the name `i18n_viz` (any value) will function the same was as if `i18n_viz=true` was in the query string.

This allows translation hints for multistep forms that don't specifically preserve the query string.