### PR TITLE
Fix nested tags, make tests pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,10 @@ rvm:
   - 2.2.4
   - 2.3.0
 before_script:
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.16.1/geckodriver-v0.16.1-linux64.tar.gz && tar -xzvf geckodriver-v0.16.1-linux64.tar.gz
+  - mkdir drivers && mv ./geckodriver drivers/
+  - export PATH="$PATH:./drivers/"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+addons:
+  firefox: "latest"

--- a/assets/javascripts/i18n_viz.js
+++ b/assets/javascripts/i18n_viz.js
@@ -40,13 +40,19 @@ $.fn.enrichWithI18nData = function() {
   return $i18n_element;
 };
 
-$.fn.clearI18nText = function() {
-  var $el;
-  $el = $(this);
-  $el.textNodes().each(function(index, node) {
-    node.textContent = node.textContent.replace(I18nViz.global_regex, "");
+function clear_i18n(el) {
+  el.contents().each(function(index, node) {
+    if (node.nodeType == 3) {
+      node.textContent = node.textContent.replace(I18nViz.global_regex, "");
+    } else {
+      return clear_i18n($(node));
+    }
   });
-  return $el;
+  return el;
+};
+
+$.fn.clearI18nText = function myself() {
+  return clear_i18n($(this));
 };
 
 $.extend($.expr[':'], {

--- a/spec/javascripts/i18n_viz_spec.coffee
+++ b/spec/javascripts/i18n_viz_spec.coffee
@@ -5,7 +5,7 @@ describe "extractI18nKeysFromText()", () ->
   it "should return i18n key when 1 present", () ->
     expect(window.I18nViz.extractI18nKeysFromText("some text --i18n.key--")).toEqual(["i18n.key"])
 
-  it "should return null with no keys present", () ->
+  it "should return all keys present", () ->
     expect(window.I18nViz.extractI18nKeysFromText("some text --i18n.key-- more text --another.key-- end")).toEqual(["i18n.key", "another.key"])
 
   it "should return null with no keys present", () ->
@@ -24,7 +24,7 @@ describe "jQuery extensions", () ->
         expect($jquery_element.text()).toEqual("some text ")
 
       it "should keep child HTML tags", () ->
-        $jquery_element.append($("<span>some more text --i18n.key2--</span>"))
+        $jquery_element.append("<span>some more text --i18n.key2--</span>")
         $jquery_element.clearI18nText()
         expect($jquery_element.text()).toEqual("some text some more text ")
         expect($jquery_element.has('span')).toBeTruthy()


### PR DESCRIPTION
@jhilden so this is an attempt to fix the mess I've created in #19 and you were so kind enough to merge without proper testing. 

The first commit fixes the version of selenium-webdriver b/c newer versions don't work with older Firefox (which we have in Travis). 

The second commit provides new implementation which keeps nested HTML tags:
```
    The previous implementation pushed with commit 83c7f8f fails the
    tests and I believe is wrong.
    
    As far as I can understand .textNodes() returns a list of all
    text nodes of the current element, which are then stripped of the
    --i18n.key-- annotations.
    
    The trouble is that .textNodes() uses .contents() which only
    searches the immediate children in the DOM tree. Thus is we have
    nested HTML tags the text nodes of these nested tags are not
    returned and the i18n annotations are not removed.
    This is indeed what is causing the existing tests to fail:
    https://travis-ci.org/railslove/i18n_viz/jobs/158501488
    
    This new implementation doesn't use .textNodes() and instead
    recurses into child nodes on its own.
```

ATM I don't have access to the Rails site which I used to integrate i18n_viz with (was a contract work and I don't have another similar Rails project). The tests now PASS and the logic above sounds like it's the right thing to do. I don't really remember what I was thinking in my previous attempt at this and we don't have any comments from the older commit.  I hope I've got it right this time.